### PR TITLE
Use cross-platform keybind for toggle fullscreen

### DIFF
--- a/unifiedRemotePlexHtpc/remote.lua
+++ b/unifiedRemotePlexHtpc/remote.lua
@@ -239,7 +239,7 @@ end
 -- @help Toggle full screen
 actions.fullScreen = function()
     actions.switch();
-    kb.press("\\");
+    kb.press("f11");
 end
 
 -- @help Toggle view mode


### PR DESCRIPTION
Tested on windows and linux, untested on mac